### PR TITLE
Setup robot build CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,30 @@
+# This is a basic workflow to build robot code.
+name: CI
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch.
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-22.04
+    # This grabs the WPILib docker container
+    container: wpilib/roborio-cross-ubuntu:2025-22.04
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v4
+    # Declares the repository safe and not under dubious ownership.
+    - name: Add repository to git safe directories
+      run: git config --global --add safe.directory $GITHUB_WORKSPACE
+    # Grant execute permission for gradlew
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    # Runs a single command using the runners shell
+    - name: Compile and run tests on robot code
+      run: ./gradlew build


### PR DESCRIPTION
Copied from https://docs.wpilib.org/en/stable/docs/software/advanced-gradlerio/robot-code-ci.html

The "2025-22.04" is correct: 
> "Since none of the dependencies changed between 2025 and 2026, the 2025 docker images are still correct to use for 2026" (WPILIB).

GRR: https://github.com/Greater-Rochester-Robotics/Rebuilt2026-340/blob/main/.github/workflows/main.yml (they also use a code formatter)